### PR TITLE
Don't force the user to have a specific node ver

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
         "url": "https://github.com/TedDriggs/inferno-monaco-editor"
     },
     "engines": {
-        "node": "8.4.0",
-        "npm": "5.3.0"
+        "node": "^8.4.0",
+        "npm": "^5.3.0"
     },
     "dependencies": {
         "monaco-editor": "~0.10.0"


### PR DESCRIPTION
This field is blocking us from using this package in our development environment, even when using the latest 8.x version. And i also wonder if this is really needed? Is there any code that needs the new features from node 8?